### PR TITLE
Implement HTTP v1 send requests

### DIFF
--- a/fcm/__init__.py
+++ b/fcm/__init__.py
@@ -1,4 +1,4 @@
-from .fcm import FCM, TopicManager  # pylint: disable=unused-import
+from .fcm import OAuthFCM, FCM, TopicManager  # pylint: disable=unused-import
 
 # -----------------------------------------------------------------------------
 

--- a/fcm/fcm.py
+++ b/fcm/fcm.py
@@ -204,6 +204,11 @@ class FCM(object):
         if self.debug:
             FCM.enable_logging()
 
+    def build_headers(self):
+        return {
+            'Authorization': 'key=%s' % self.api_key,
+        }
+
     @staticmethod
     def enable_logging(level=logging.DEBUG, handler=None):
         """
@@ -284,9 +289,7 @@ class FCM(object):
         :raises FCMConnectionException: if FCM is screwed
         """
 
-        headers = {
-            'Authorization': 'key=%s' % self.api_key,
-        }
+        headers = self.build_headers()
 
         if is_json:
             headers['Content-Type'] = 'application/json'
@@ -836,3 +839,20 @@ class TopicManager(object):
 
         url = '{}/info/{}{}'.format(self.url, registration_id, '?details=true' if details is True else '')
         return self.json_request(method='get', url=url)
+
+
+class OAuthFCM(FCM):
+    def __init__(self, access_token, proxy=None, timeout=None, debug=False):
+        """
+        :param access_token: OAuth 2.0 access token
+        :param proxy: can be string "http://host:port" or dict {'https':'host:port'}
+        :param timeout: timeout for every HTTP request, see 'requests' documentation for possible values.
+        """
+        self.access_token = access_token
+
+        super(OAuthFCM, self).__init__(access_token, proxy, timeout, debug)
+
+    def build_headers(self):
+        return {
+            'Authorization': 'Bearer %s' % self.access_token,
+        }

--- a/fcm/test.py
+++ b/fcm/test.py
@@ -449,7 +449,7 @@ class FCMTest(unittest.TestCase):
         self.assertTrue(type(FCM.logger), MagicMock)
         FCM.enable_logging()
         self.assertEqual(FCM.logger.debug.call_count, 2)
-        FCM.logger.debug.assert_any_call('Added a stderr logging handler to logger: fcm')
+        FCM.logger.debug.assert_any_call('Added a stderr logging handler to logger: fcm.fcm')
         FCM.logger.debug.assert_any_call('Added a stderr logging handler to logger: requests.packages.urllib3')
 
     @patch('fcm.logging.getLogger')
@@ -457,7 +457,7 @@ class FCMTest(unittest.TestCase):
         self.assertTrue(type(FCM.logger), MagicMock)
         fcm = FCM('123api', debug=True)
         self.assertEqual(fcm.logger.debug.call_count, 2)
-        fcm.logger.debug.assert_any_call('Added a stderr logging handler to logger: fcm')
+        fcm.logger.debug.assert_any_call('Added a stderr logging handler to logger: fcm.fcm')
         fcm.logger.debug.assert_any_call('Added a stderr logging handler to logger: requests.packages.urllib3')
 
     @patch('requests.Session.post')


### PR DESCRIPTION
The current implementation uses the legacy protocol (API key), the new way of doing things is by using an access token.

See https://firebase.google.com/docs/cloud-messaging/auth-server#authorize_http_v1_send_requests